### PR TITLE
Add gcc dependency

### DIFF
--- a/Formula/acton.rb
+++ b/Formula/acton.rb
@@ -25,6 +25,7 @@ class Acton < Formula
   end
 
   on_linux do
+    depends_on "gcc"
     depends_on "gmp"
     depends_on "libbsd" => :build
   end


### PR DESCRIPTION
Mac comes with a C compiler so we dont have an explicit dependency
defined there. On Linux however, that's not the case. Need to
explicitly list!