### PR TITLE
Enable parallel builds

### DIFF
--- a/Formula/acton.rb
+++ b/Formula/acton.rb
@@ -33,7 +33,6 @@ class Acton < Formula
 
   def install
     ENV["BUILD_RELEASE"] = "1"
-    ENV.deparallelize
     system "make"
     bin.install "dist/bin/actonc"
     bin.install "dist/bin/actondb"


### PR DESCRIPTION
I believe we have solved any parallel build problems, so we can safely
remove the ENV.deparallelize statement now.