### PR TITLE
Turn off matrix fail-fast

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   test-bot:
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-10.15, macos-11, ubuntu-20.04]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This will allow us to see the build output of the other builds even if
one fails in the matrix. I think this will be useful. Quite a lot of the
time the linux build fails first, because it runs faster, but then we
have no idea what the build result is like on macos because those builds
were canceled.