### PR TITLE
Use system GHC

### DIFF
--- a/Formula/acton.rb
+++ b/Formula/acton.rb
@@ -13,6 +13,7 @@ class Acton < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "8182bd70952c8a817ec2749f2eaf3ceb12cfadaae7a2668fb78439ccffe85960"
   end
 
+  depends_on "ghc" => :build
   depends_on "haskell-stack" => :build
 
   depends_on "protobuf-c"
@@ -30,6 +31,13 @@ class Acton < Formula
   end
 
   def install
+    # Fix up stack config to not install project local GHC
+    inreplace "compiler/stack.yaml", "# system-ghc: true", <<~EOS
+      system-ghc: true
+      install-ghc: false
+      allow-newer: true
+    EOS
+
     ENV["BUILD_RELEASE"] = "1"
     system "make"
     bin.install "dist/bin/actonc"


### PR DESCRIPTION
Rather than having stack install a project local ghc, we use the system
ghc. This is apparently the Homebrew way. If we want this Formula to be
accepted into homebrew-core, we wouldn't be allowed to use a project
local stack install of GHC, it would have to be using a system ghc (and
depend on a ghc installed via homebrew!).

This is all good because it also fixes one of the other problems we had;
namely that the latest haskell-stack version doesn't know how to install
GHC on Apple M1 silicon. Our workaround has been to install the latest
from git with `brew install --HEAD haskell-stack` but since the Homebrew
GHC formula works out of the box on the M1, it now just starts working.
We still can't provide a pre-built ("bottled") version of our Acton
package, but with this fix, it should be possible to simply to a `brew
install actonlang/acton/acton` on an M1 and it should just work. It will
build it from source!