### PR TITLE
Use github.token

### DIFF
--- a/.github/workflows/test-success.yml
+++ b/.github/workflows/test-success.yml
@@ -23,6 +23,5 @@ jobs:
           sha: ${{ steps.find-pull-request.outputs.head-sha }}
       - uses: actions-ecosystem/action-add-labels@v1
         with:
-          github_token: ${{ secrets.ACTBOT_PAT }}
           labels: pr-pull
           number: ${{ steps.find-pull-request.outputs.number }}


### PR DESCRIPTION
I think the default value of ${{ github.token }} should work just fine for this use case.