### PR TITLE
Harden release pr-pull automation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,16 +5,25 @@ on:
     types:
       - labeled
 
+permissions:
+  contents: write
+  packages: write
+  pull-requests: read
+
 jobs:
   pr-pull:
-    if: contains(github.event.pull_request.labels.*.name, 'pr-pull')
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'pr-pull') &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'acton-v')
     runs-on: ubuntu-latest
     steps:
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
 
       - name: Set up git
-        uses: Homebrew/actions/git-user-config@master
+        uses: Homebrew/actions/git-user-config@main
 
       - name: Pull bottles
         env:
@@ -26,7 +35,7 @@ jobs:
         run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
 
       - name: Push commits
-        uses: Homebrew/actions/git-try-push@master
+        uses: Homebrew/actions/git-try-push@main
         with:
           token: ${{ github.token }}
           branch: main

--- a/.github/workflows/test-success.yml
+++ b/.github/workflows/test-success.yml
@@ -1,28 +1,47 @@
-# This workflow is triggered when the test workflow completes successfully, so
-# we can tack on the pr-pull label which in turn will trigger the publish
-# workflow.
-name: Merge successfull test job PRs
+name: Auto-label release PRs for pr-pull
+
 on:
   workflow_run:
     workflows: ["brew test-bot"]
     types: [completed]
 
+permissions:
+  contents: read
+
 jobs:
-  on-success:
+  add-pr-pull-label:
+    name: Add pr-pull to successful release PR
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      startsWith(github.event.workflow_run.head_branch, 'acton-v')
     steps:
-      - name: Find Pull Request
-        uses: juliangruber/find-pull-request-action@v1
-        id: find-pull-request
-        with:
-          branch: ${{ github.event.workflow_run.head_branch }}
-      - run: echo "Pull Request ${number} (${sha})"
+      - name: Add pr-pull label
         env:
-          number: ${{ steps.find-pull-request.outputs.number }}
-          sha: ${{ steps.find-pull-request.outputs.head-sha }}
-      - uses: actions-ecosystem/action-add-labels@v1
-        with:
-          labels: pr-pull
-          number: ${{ steps.find-pull-request.outputs.number }}
-          github_token: ${{ secrets.ACTBOT_PAT }}
+          # A PAT is required because events created by GITHUB_TOKEN do not
+          # trigger the pull_request_target workflow that publishes bottles.
+          GH_TOKEN: ${{ secrets.ACTBOT_PAT }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          pr_number="$(gh pr list \
+            --repo "$REPO" \
+            --state open \
+            --base main \
+            --head "$BRANCH" \
+            --json number,headRefOid \
+            --jq ".[] | select(.headRefOid == \"$HEAD_SHA\") | .number" \
+            | head -n 1)"
+
+          if [ -z "$pr_number" ]; then
+            echo "No open release PR found for $BRANCH at $HEAD_SHA"
+            exit 1
+          fi
+
+          echo "Adding pr-pull to PR $pr_number"
+          gh pr edit "$pr_number" --repo "$REPO" --add-label pr-pull

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache


### PR DESCRIPTION
## Summary

- restrict automatic `pr-pull` labeling to successful same-repository `acton-v*` release PRs
- keep `ACTBOT_PAT` for label application so the downstream `pull_request_target` publish workflow is triggered
- gate the publish workflow to the same release-PR shape before running `brew pr-pull`
- move Homebrew actions from deprecated `master` refs to `main`

## Verification

- Parsed `.github/workflows/test-success.yml`, `.github/workflows/publish.yml`, and `.github/workflows/tests.yml` with Ruby YAML
- Ran `git diff --check` on the changed workflow files
- Checked `gh pr list --help` for the flags used by the auto-label script