### PR TITLE
Use REST API for pr-pull auto-label

### DIFF
--- a/.github/workflows/test-success.yml
+++ b/.github/workflows/test-success.yml
@@ -44,4 +44,7 @@ jobs:
           fi
 
           echo "Adding pr-pull to PR $pr_number"
-          gh pr edit "$pr_number" --repo "$REPO" --add-label pr-pull
+          gh api \
+            --method POST \
+            "repos/$REPO/issues/$pr_number/labels" \
+            -f labels[]=pr-pull >/dev/null


### PR DESCRIPTION
The auto-label workflow currently uses `gh pr edit --add-label`, which goes through GraphQL and requires org-readable fields the release PAT does not have. The job already finds the release PR correctly, but fails while applying the label.

This switches the label write to GitHub's REST issue-labels endpoint while keeping `ACTBOT_PAT`, so the label event still comes from a PAT and can trigger the bottle publish workflow.